### PR TITLE
feat: add rounding options for toString()

### DIFF
--- a/dms.ts
+++ b/dms.ts
@@ -87,11 +87,13 @@ export class Dms {
     }
     /**
      * Returns the DMS value as a string.
+     * @param {number} [precision] - number of digits after the decimal point in seconds 
      * @returns {string}
      */
-    public toString(): string {
+    public toString(precision?: number): string {
         const dmsArray = this.getDmsArray();
-        return `${dmsArray[0]}°${dmsArray[1]}′${dmsArray[2]}″ ${dmsArray[3]}`;
+        const second = isNaN(Number(precision)) ? dmsArray[2] : dmsArray[2].toFixed(precision);
+        return `${dmsArray[0]}°${dmsArray[1]}′${second}″ ${dmsArray[3]}`;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dms-conversion",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A JavaScript library for converting between decimal degrees and degrees, minutes, and seconds (DMS).",
   "main": "dist/node/dms.js",
   "browser": "dist/browser/dms.js",

--- a/spec/dmsSpec.ts
+++ b/spec/dmsSpec.ts
@@ -57,4 +57,18 @@ describe("DmsCoordinates", () => {
     expect(dmsCoordsEast[0]).toEqual(dmsCoordsWest[0]);
     expect(dmsCoordsWest[1]).toBeLessThan(0);
   });
+
+  describe('toString() rounding', ()=>{
+    let dmsCoords: DmsCoordinates;
+    beforeEach(()=>{
+      dmsCoords = new DmsCoordinates(lat, long);
+    })
+    it('should be able to round digits in second', ()=>{
+      expect(dmsCoords.latitude.toString(3)).toEqual('46°59′4.508″ N');
+    })
+  
+    it('should not round when precision not provided', ()=>{
+      expect(dmsCoords.latitude.toString()).toMatch(/46°59′4.50770327\d+″ N/i);
+    })
+  })
 });


### PR DESCRIPTION
add new feature to round to fixed digits after decimal point in the toString() output.